### PR TITLE
Ignore Steel Fences from Immersive Engineering

### DIFF
--- a/src/main/resources/data/diagonalfences/tags/blocks/non_diagonal_fences.json
+++ b/src/main/resources/data/diagonalfences/tags/blocks/non_diagonal_fences.json
@@ -4,6 +4,10 @@
     {
       "id": "assorteddecor:colorizer_fence",
       "required": false
+    },
+    {
+      "id": "immersiveengineering:steel_fence",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
In "Immersive Petroleum", an extension for "Immersive Engineering", the Steel Fences are used for Multiblock Structures. (Otherwise, the Multiblock is not Working - Example Structure: Derrick) I guess it would be good, that these Fences are completely ignored.

On our Server this change works :)